### PR TITLE
Add excludeSelf option to filewatch library

### DIFF
--- a/lib/filewatch.js
+++ b/lib/filewatch.js
@@ -7,7 +7,7 @@ const rel = (filepath)=>path.relative(process.cwd(), filepath);
 module.exports = (filepath, opts={})=>{
 	return nodemon({ script:filepath, delay:2,
 		...opts,
-		watch: (opts.watch || []).concat(path.dirname(filepath)),
+		watch: opts.excludeSelf ? (opts.watch || []) : (opts.watch || []).concat(path.dirname(filepath)),
 	})
 		.on('restart', (changedFiles)=>{
 			//TODO: Make these prettier


### PR DESCRIPTION
Adding the `excludeSelf` option to the `filewatch` library allows the user to not concatenate the directory of the `filepath` object to the watched directory list. If this option is false or unset, the previous functionality is preserved.