### PR TITLE
Change root target to `reactRoot` rather than `main`

### DIFF
--- a/lib/pack.js
+++ b/lib/pack.js
@@ -61,7 +61,7 @@ module.exports = async (entrypoint, _opts={})=>{
 		const Core = await runBundler(bundler);
 
 		const renderAsString = `;const comp=module.exports;${!!opts.dev ? 'delete require.cache[__filename];' : ''};module.exports=(props)=>require('react-dom/server').renderToString(require('react').createElement(comp, props))`;
-		const clientSideHydrate = `;start_app=(props={},target=document.getElementsByTagName('main')[0])=>require('react-dom/client').hydrateRoot(target,require('react').createElement(${opts.name}, props));`
+		const clientSideHydrate = `;start_app=(props={},target=document.getElementById('reactRoot')[0])=>require('react-dom/client').hydrateRoot(target,require('react').createElement(${opts.name}, props));`
 
 		console.timeEnd(chalk.cyan(`bundled ${entrypoint}`));
 		return {


### PR DESCRIPTION
Changes the selector for the root of the app to the id `reactRoot` rather than the tag `<main>`.  `<main>` should be used as a container for the most important content on a page, not used as a wrapper for an entire app.

In terms of what this means for the Homebrewery, it doesn't mean much.  We already use the id `reactRoot` on the same element.  It will allow us to set a correct `main` element around everything except the top navbar (or more selectively just on the editor, or renderer, or whatever we decide).

I want to free up the `main` tag because it is a primary `landmark` role that can be useful for screen readers.